### PR TITLE
Update platformio.ini

### DIFF
--- a/CO2-Code/platformio.ini
+++ b/CO2-Code/platformio.ini
@@ -14,7 +14,3 @@ board = mayfly
 framework = arduino
 lib_deps = 
 	adafruit/Adafruit ADS1X15@^2.4.0
-	adafruit/Adafruit Unified Sensor@^1.1.13
-	adafruit/SD@0.0.0-alpha+sha.041f788250
-	northernwidget/DS3231@^1.1.2
-	adafruit/Adafruit BME280 Library@^2.2.2


### PR DESCRIPTION
Removes some libraries from .ini file that are no longer needed in the updated co2-sensor.cpp code.